### PR TITLE
use r_packages to be consistent with readme.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ sudo: required
 
 env: _R_CHECK_CRAN_INCOMING_=FALSE
 
+r_packages:
+  - covr
+
 r_github_packages:
-  - jimhester/covr
   - codecov/example-r
 
 after_success:


### PR DESCRIPTION
The Readme states just use r_packages; presumably the GitHub repository is now also on CRAN?